### PR TITLE
Add aarch64 linux support

### DIFF
--- a/actions/desktop-deploy/index.js
+++ b/actions/desktop-deploy/index.js
@@ -86,6 +86,10 @@ const runAction = () => {
         setEnv("CSC_KEY_PASSWORD", getInput("windows_certs_password"));
     }
 
+    if (platform === "linux") {
+        runtimeArgs += "--x64 --arm64";
+    }
+    
     log(`Building${release ? " and releasing" : ""} the Electron app…`);
     const fullCmd = `node_modules/.bin/electron-builder  --${platform} ${
         release ? "--publish always" : "--publish=never"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux desktop releases now include both x64 and ARM64 builds, expanding compatibility across more devices.

* **Chores**
  * Updated deployment pipeline to produce multi-architecture Linux artifacts in a single build run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->