### PR TITLE
Temporarily make tooltips a button title

### DIFF
--- a/apps/desktop/src/components/RegisteredActionButton.tsx
+++ b/apps/desktop/src/components/RegisteredActionButton.tsx
@@ -79,46 +79,51 @@ export default function RegisteredActionButton({
         removeRegisteredAction,
     ]);
 
-    if (showTooltip)
-        return (
-            <RadixTooltip.Root>
-                <RadixTooltip.Trigger
-                    {...rest}
-                    ref={buttonRef}
-                    className={twMerge(
-                        clsx(
-                            "enabled:hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-                            rest.className,
-                        ),
-                    )}
-                >
-                    {children}
-                </RadixTooltip.Trigger>
-                <RadixTooltip.Portal>
-                    <RadixTooltip.Content
-                        className={TooltipClassName}
-                        side={tooltipPosition}
-                    >
-                        {instructionalString
-                            ? instructionalString
-                            : registeredAction.getInstructionalString()}
-                    </RadixTooltip.Content>
-                </RadixTooltip.Portal>
-            </RadixTooltip.Root>
-        );
-    else
-        return (
-            <button
-                {...rest}
-                ref={buttonRef}
-                className={twMerge(
-                    clsx(
-                        "enabled:hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-                        rest.className,
-                    ),
-                )}
-            >
-                {children}
-            </button>
-        );
+    // if (showTooltip)
+    //     return (
+    //         <RadixTooltip.Root>
+    //             <RadixTooltip.Trigger
+    //                 {...rest}
+    //                 ref={buttonRef}
+    //                 className={twMerge(
+    //                     clsx(
+    //                         "enabled:hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+    //                         rest.className,
+    //                     ),
+    //                 )}
+    //             >
+    //                 {children}
+    //             </RadixTooltip.Trigger>
+    //             <RadixTooltip.Portal>
+    //                 <RadixTooltip.Content
+    //                     className={TooltipClassName}
+    //                     side={tooltipPosition}
+    //                 >
+    //                     {instructionalString
+    //                         ? instructionalString
+    //                         : registeredAction.getInstructionalString()}
+    //                 </RadixTooltip.Content>
+    //             </RadixTooltip.Portal>
+    //         </RadixTooltip.Root>
+    //     );
+    // else
+    return (
+        <button
+            {...rest}
+            ref={buttonRef}
+            title={
+                instructionalString
+                    ? instructionalString
+                    : registeredAction.getInstructionalString()
+            }
+            className={twMerge(
+                clsx(
+                    "enabled:hover:text-accent outline-hidden duration-150 ease-out focus-visible:-translate-y-4 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+                    rest.className,
+                ),
+            )}
+        >
+            {children}
+        </button>
+    );
 }


### PR DESCRIPTION
Temporary fix to make buttons work.


https://github.com/user-attachments/assets/aca7c0c9-4b53-4f55-b916-16c7f3465fd3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the Registered Action button to always render a single button.
  - Replaced the custom tooltip UI with a native browser title attribute for hover hints.
  - Ensures consistent behavior and reduces UI complexity without altering styling.

- **UI/UX**
  - Hovering the action button now shows a native tooltip instead of a popover.

- **Chores**
  - No changes to public APIs or external interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->