### PR TITLE
Hotfix - edit notes on first page

### DIFF
--- a/apps/desktop/src/components/inspector/PageEditor.tsx
+++ b/apps/desktop/src/components/inspector/PageEditor.tsx
@@ -135,7 +135,6 @@ function PageEditor() {
                             ) => setNotes(e.target.value)}
                             onBlur={handleNotesBlur}
                             placeholder={t("inspector.page.notesPlaceholder")}
-                            disabled={isFirstPage}
                         />
                     </div>
                     <Button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where page notes were locked and unavailable for editing on the first page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->