### PR TITLE
Fix page count editing occasionally giving the same counts

### DIFF
--- a/apps/desktop/src/global/classes/Beat.ts
+++ b/apps/desktop/src/global/classes/Beat.ts
@@ -150,10 +150,18 @@ export const durationToBeats = ({
 
     while (beatIndex < allBeats.length) {
         const nextBeatDuration = allBeats[beatIndex].duration;
-        // Check if adding this beat would exceed the target
-        if (cumulativeDuration + nextBeatDuration > newDuration) {
+
+        // Check if adding this beat gets us closer to the target
+        const distanceWithoutBeat = Math.abs(newDuration - cumulativeDuration);
+        const distanceWithBeat = Math.abs(
+            newDuration - (cumulativeDuration + nextBeatDuration),
+        );
+
+        // If adding the beat makes us further from the target, stop
+        if (distanceWithBeat > distanceWithoutBeat) {
             break;
         }
+
         cumulativeDuration += nextBeatDuration;
         beatIndex++;
     }


### PR DESCRIPTION
When dragging the page to change counts, occasionally the counts would not change as expected

## Before
https://github.com/user-attachments/assets/310cb852-b895-4d1d-8970-81debdb037ad

## After
https://github.com/user-attachments/assets/ca430968-47e1-4978-a0f2-0b0bcd76bde6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved beat duration calculation accuracy to ensure beats properly align within target durations without exceeding boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->