### PR TITLE
Fix color picker rendering off screen

### DIFF
--- a/apps/desktop/src/components/ui/ColorPicker.tsx
+++ b/apps/desktop/src/components/ui/ColorPicker.tsx
@@ -107,7 +107,11 @@ export default function ColorPicker({
                     <Popover.Portal>
                         <Popover.Content
                             align="start"
-                            className="rounded-6 shadow-modal animate-fade-in absolute z-50 mt-8 bg-white p-2"
+                            side="bottom"
+                            sideOffset={8}
+                            collisionPadding={20}
+                            avoidCollisions={true}
+                            className="rounded-6 shadow-modal animate-fade-in z-50 bg-white p-2"
                         >
                             <div className="z-50 my-8 flex items-center justify-between px-12">
                                 <Popover.Close


### PR DESCRIPTION
fix #556

When opening the color picker at the bottom of the page, it would go off screen. The solution is to render it on top of the trigger when at the bottom

## Before
<img width="645" height="492" alt="pick" src="https://github.com/user-attachments/assets/bd619a01-0d5a-438e-b9d4-ec7631547485" />

## After
<img width="728" height="651" alt="image" src="https://github.com/user-attachments/assets/d71ee915-c320-49e5-82a5-d5eebafe3248" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color picker popover positioning with collision detection. The popover now dynamically adjusts its placement to prevent being cut off by screen edges, enhancing visibility and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->