### PR TITLE
Add outline when there is no transparency

### DIFF
--- a/apps/desktop/src/global/classes/canvasObjects/CanvasMarcher.ts
+++ b/apps/desktop/src/global/classes/canvasObjects/CanvasMarcher.ts
@@ -110,12 +110,19 @@ export default class CanvasMarcher
         } else if (shapeType === "x") {
             // Create an X shape using two crossing lines
             const xSize = dotRadius * 1.2;
+            // Use fillColor for X stroke to ensure visibility, since X has no fill area
+            // and outline color might be transparent
+            const xStrokeColor =
+                sectionAppearance?.outline_color &&
+                sectionAppearance.outline_color.a > 0.1
+                    ? outlineColor
+                    : fillColor;
             const line1 = new fabric.Line([-xSize, -xSize, xSize, xSize], {
-                stroke: outlineColor,
+                stroke: xStrokeColor,
                 strokeWidth: 2,
             });
             const line2 = new fabric.Line([-xSize, xSize, xSize, -xSize], {
-                stroke: outlineColor,
+                stroke: xStrokeColor,
                 strokeWidth: 2,
             });
             markerShape = new fabric.Group([line1, line2], {


### PR DESCRIPTION
fix #628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced X marker visibility on the canvas. Stroke color rendering now intelligently adapts based on outline opacity settings. When outlines have minimal opacity, the system automatically selects alternative colors for optimal visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->