### PR TITLE
Use correct counts for new last page

### DIFF
--- a/apps/desktop/src/db-functions/page.ts
+++ b/apps/desktop/src/db-functions/page.ts
@@ -804,7 +804,7 @@ const _getNextBeatToStartOn = async ({
             where: (table, { gte }) =>
                 gte(table.position, lastPageBeat.position),
             orderBy: (table, { asc }) => asc(table.position),
-            offset: newPageCounts,
+            offset: lastPageCounts,
         });
         if (!nextBeat) throw new Error("Not enough beats to create a new page");
         return nextBeat;


### PR DESCRIPTION
just was using the wrong variable when creating a new page

fix #717


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the page break calculation logic to ensure proper page layout generation when existing page data is used as reference, improving pagination accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->