### PR TITLE
explicitly check for zero coordinate

### DIFF
--- a/apps/desktop/src/global/classes/canvasObjects/ShapePointController.ts
+++ b/apps/desktop/src/global/classes/canvasObjects/ShapePointController.ts
@@ -115,7 +115,7 @@ export class ShapePointController extends fabric.Circle {
             console.error("The parent path does not have a path");
             return;
         }
-        if (!this.left || !this.top) {
+        if (this.left == null || this.top == null) {
             console.error("The control point does not have coordinates");
             return;
         }
@@ -185,7 +185,11 @@ export class ShapePointController extends fabric.Circle {
     moveHandler(event: fabric.IEvent<MouseEvent>) {
         roundCoordinatesHandler(this, event);
         this.marcherShape.shapePath.objectCaching = false;
-        if (this.marcherShape.shapePath.path && this.left && this.top) {
+        if (
+            this.marcherShape.shapePath.path &&
+            this.left != null &&
+            this.top != null
+        ) {
             this.refreshParentPathCoordinates();
             this.marcherShape.distributeMarchers();
             this.marcherShape.bringControlPointsToFront();
@@ -245,7 +249,7 @@ export class ShapePointController extends fabric.Circle {
             // There is no outgoing point, return null
             return null;
         }
-        if (!this.outgoingPoint.left || !this.outgoingPoint.top) {
+        if (this.outgoingPoint.left == null || this.outgoingPoint.top == null) {
             console.error("The outgoing point has no coordinates");
             return null;
         }

--- a/apps/desktop/src/hooks/queries/usePathways.ts
+++ b/apps/desktop/src/hooks/queries/usePathways.ts
@@ -121,7 +121,7 @@ export const pathwaysByPageQueryOptions = (pageId: number) => {
     return queryOptions<PathwaysById>({
         queryKey: pathwayKeys.byPageId(pageId),
         queryFn: () => pathwayQueries.getByPageId(pageId, db),
-        enabled: !!pageId,
+        enabled: pageId != null,
         staleTime: DEFAULT_STALE_TIME,
     });
 };


### PR DESCRIPTION
The coordinate was not being applied when a shape was brought to a leftmost or topmost coordinate due to an implicit boolean comparison on null/zero values

I'd like to make an eslint rule that specifically shows an error on these types of behaviors for non-length numerical checks

fix #710



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected coordinate validation logic in shape point tracking to properly handle zero-valued coordinates as valid positions instead of treating them as missing values.
  * Fixed page identifier validation in data queries to recognize zero as a valid ID, ensuring correct query behavior for all valid identifiers and preventing query failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->