### PR TITLE
Add transaction to history

### DIFF
--- a/apps/desktop/src/db-functions/history.ts
+++ b/apps/desktop/src/db-functions/history.ts
@@ -699,31 +699,37 @@ async function executeHistoryAction(
             await switchTriggerMode(db, "undo", false, tableNames);
         }
 
-        // Temporarily disable foreign key checks
-        await db.run(sql.raw("PRAGMA foreign_keys = OFF;"));
+        let error: Error | undefined;
+        try {
+            // Temporarily disable foreign key checks
+            await db.run(sql.raw("PRAGMA foreign_keys = OFF;"));
 
-        /// Execute all of the SQL statements in the current history group
-        await db.transaction(async (tx) => {
-            for (const sqlStatement of sqlStatements) {
-                await tx.run(sqlStatement);
-            }
-        });
+            /// Execute all of the SQL statements in the current history group
+            await db.transaction(async (tx) => {
+                for (const sqlStatement of sqlStatements)
+                    await tx.run(sqlStatement);
+            });
+        } catch (err: any) {
+            error = err;
+        } finally {
+            // Re-enable foreign key checks
+            await db.run(sql.raw("PRAGMA foreign_keys = ON;"));
 
-        // Re-enable foreign key checks
-        await db.run(sql.raw("PRAGMA foreign_keys = ON;"));
+            // Switch the triggers back to undo mode and delete the redo rows when inputting new undo rows
+            await switchTriggerMode(db, "undo", true, tableNames);
+        }
+
+        if (error) throw error;
 
         // Delete all of the SQL statements in the current history group
         await db.run(
             sql.raw(`
-            DELETE FROM ${tableName} WHERE "history_group"=${currentGroup};
-        `),
+        DELETE FROM ${tableName} WHERE "history_group"=${currentGroup};
+    `),
         );
-
         // Refresh the current group number in the history stats table
         await refreshCurrentGroups(db);
 
-        // Switch the triggers back to undo mode and delete the redo rows when inputting new undo rows
-        await switchTriggerMode(db, "undo", true, tableNames);
         response = {
             success: true,
             tableNames,


### PR DESCRIPTION
This is just a good idea. There were cases when some actions in history were performed and others weren't

fix #775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap execution of undo/redo SQL statements for the current history group in a single transaction to make the operation atomic.
> 
> - **DB history execution (`apps/desktop/src/db-functions/history.ts`)**:
>   - Execute all SQL statements for the current undo/redo `history_group` within a `db.transaction`, using `tx.run` instead of `db.run`, ensuring the group applies atomically.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26f2ea570c2a9983dc3188ebf5e819698462f110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * History actions now execute as a single atomic batch, improving reliability and centralizing error handling.
  * Ensures foreign key checks are always restored after execution.
  * Adjusts trigger switching and group cleanup to occur after the grouped execution and refreshes current history groups.

* **Chores**
  * No public interfaces or exported APIs were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->