### PR TITLE
Maintain order on fixed marcher distribution

### DIFF
--- a/apps/desktop/src/components/inspector/MarcherEditor.tsx
+++ b/apps/desktop/src/components/inspector/MarcherEditor.tsx
@@ -185,19 +185,23 @@ function AlignmentButtons({ editingDisabled }: AlignmentButtonsProps) {
             if (currentCoordinates.length === 0) return currentCoordinates;
             const stepValue = parseStepInterval(horizontalStepInterval);
 
+            if (!fieldProperties) return currentCoordinates;
+
             if (!stepValue) {
-                if (!fieldProperties) return currentCoordinates;
                 return evenlyDistributeHorizontally({
                     coordinates: currentCoordinates,
                     fieldProperties,
                 });
             }
 
-            if (!fieldProperties) return currentCoordinates;
             const interval = stepValue * fieldProperties.pixelsPerStep;
-            const startingX = Number(currentCoordinates[0]?.x ?? 0);
+            const leftToRightMarchers = currentCoordinates.sort(
+                (a, b) => a.x - b.x,
+            );
+            if (leftToRightMarchers.length === 0) return currentCoordinates;
 
-            return currentCoordinates.map((coordinate, index) => ({
+            const startingX = Number(leftToRightMarchers[0].x);
+            return leftToRightMarchers.map((coordinate, index) => ({
                 ...coordinate,
                 x: startingX + index * interval,
             }));
@@ -214,19 +218,23 @@ function AlignmentButtons({ editingDisabled }: AlignmentButtonsProps) {
             if (currentCoordinates.length === 0) return currentCoordinates;
             const stepValue = parseStepInterval(verticalStepInterval);
 
+            if (!fieldProperties) return currentCoordinates;
+
             if (!stepValue) {
-                if (!fieldProperties) return currentCoordinates;
                 return evenlyDistributeVertically({
                     coordinates: currentCoordinates,
                     fieldProperties,
                 });
             }
 
-            if (!fieldProperties) return currentCoordinates;
             const interval = stepValue * fieldProperties.pixelsPerStep;
-            const startingY = Number(currentCoordinates[0]?.y ?? 0);
+            const topToBottomMarchers = currentCoordinates.sort(
+                (a, b) => a.y - b.y,
+            );
+            if (topToBottomMarchers.length === 0) return currentCoordinates;
 
-            return currentCoordinates.map((coordinate, index) => ({
+            const startingY = Number(topToBottomMarchers[0].y);
+            return topToBottomMarchers.map((coordinate, index) => ({
                 ...coordinate,
                 y: startingY + index * interval,
             }));


### PR DESCRIPTION
The original implementation would adjust the order of marchers based on the location they happened to be in the coordinate array.

This fix applies the coordiante distribution from left-to-right and top-to-bottom


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal and vertical distribution accuracy with enhanced validation and more predictable results. The feature now establishes a consistent starting position when applying numeric intervals, making formations more reliable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->