### PR TITLE
Fix for issue 632 (shapes showing when animation is playing)

### DIFF
--- a/apps/desktop/src/components/canvas/Canvas.tsx
+++ b/apps/desktop/src/components/canvas/Canvas.tsx
@@ -29,6 +29,7 @@ import { useSelectionStore } from "@/stores/SelectionStore";
 import { useSelectionListeners } from "./hooks/canvasListeners.selection";
 import { useMovementListeners } from "./hooks/canvasListeners.movement";
 import { useRenderMarcherShapes } from "./hooks/shapes";
+import { ShapePath } from "@/global/classes/canvasObjects/ShapePath";
 
 /**
  * The field/stage UI of OpenMarch
@@ -96,7 +97,7 @@ export default function Canvas({
     useSelectionListeners({ canvas });
     useMovementListeners({ canvas });
     useAnimation({ canvas });
-    useRenderMarcherShapes({ canvas, selectedPage });
+    useRenderMarcherShapes({ canvas, selectedPage, isPlaying });
 
     // Function to center and fit the canvas to the container
     const centerAndFitCanvas = useCallback(() => {
@@ -477,6 +478,14 @@ export default function Canvas({
     }, [canvas, centerAndFitCanvas, isFullscreen]);
 
     /* --------------------------Animation Functions-------------------------- */
+
+    // This effect ensures that when the animation is playing, the shape paths
+    // are removed from the canvas.
+    useEffect(() => {
+        if (canvas && isPlaying && selectedPage) {
+            canvas.removeAllObjectsByType(ShapePath);
+        }
+    }, [canvas, isPlaying, selectedPage]);
 
     // This effect ensures that when the animation is paused, the marchers are
     // rendered at their final positions for the selected page.

--- a/apps/desktop/src/components/canvas/hooks/shapes.ts
+++ b/apps/desktop/src/components/canvas/hooks/shapes.ts
@@ -10,9 +10,11 @@ import { useEffect } from "react";
 export const useRenderMarcherShapes = ({
     canvas,
     selectedPage,
+    isPlaying,
 }: {
     canvas: OpenMarchCanvas | null;
     selectedPage: Page | null;
+    isPlaying: boolean;
 }) => {
     const { data: shapePagesOnSelectedPage } = useQuery(
         shapePagesQueryByPageIdOptions(selectedPage?.id!),
@@ -22,8 +24,9 @@ export const useRenderMarcherShapes = ({
     );
 
     // Update/render the MarcherShapes when the selected page or the ShapePages change
+    // and the animation is not playing.
     useEffect(() => {
-        if (canvas && shapePagesOnSelectedPage) {
+        if (canvas && shapePagesOnSelectedPage && !isPlaying) {
             void canvas.renderMarcherShapes({
                 shapePages: shapePagesOnSelectedPage,
             });
@@ -31,6 +34,7 @@ export const useRenderMarcherShapes = ({
     }, [
         canvas,
         selectedPage,
+        isPlaying,
         shapePagesOnSelectedPage,
         shapePageMarchersOnSelectedPage,
     ]);


### PR DESCRIPTION
Shapes now hide while the animation is playing and are re-rendered when the animation is paused.

fix #632

https://github.com/user-attachments/assets/c17ff7d3-af04-4e01-b00f-afebbdb0f5b5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animation playback behavior to automatically clear shapes from the canvas when playback begins. This eliminates visual conflicts between static shape designs and dynamic animation rendering, delivering a cleaner, more predictable playback experience. Shape visibility is now properly managed throughout the entire animation playback cycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->