### PR TITLE
Refactor PageNotesSection to display next page's notes during playback

### DIFF
--- a/apps/desktop/src/components/inspector/PageNotesSection.tsx
+++ b/apps/desktop/src/components/inspector/PageNotesSection.tsx
@@ -29,10 +29,10 @@ export function PageNotesSection() {
     const editingPageIdRef = useRef<number | null>(null);
 
     useEffect(() => {
-        if (displayPage && editingPageIdRef.current === null) {
+        if (displayPage && (isPlaying || editingPageIdRef.current === null)) {
             setNotes(displayPage.notes || "");
         }
-    }, [displayPage]);
+    }, [displayPage, isPlaying]);
 
     const handleNotesBlur = (nextNotesHtml: string) => {
         if (!displayPage) return;
@@ -88,6 +88,7 @@ export function PageNotesSection() {
                 <div className="input-group">
                     <NotesRichTextEditor
                         value={notes}
+                        editable={!isPlaying}
                         onChange={setNotes}
                         onBlur={handleNotesBlur}
                         onEditorFocus={() => {

--- a/apps/desktop/src/components/notes/NotesRichTextEditor.tsx
+++ b/apps/desktop/src/components/notes/NotesRichTextEditor.tsx
@@ -7,6 +7,8 @@ import "./NotesRichTextEditor.css";
 
 type NotesRichTextEditorProps = {
     value: string;
+    /** When false, editor is read-only. Default true. */
+    editable?: boolean;
     /** Optional; called when the editor commits content (on blur). */
     onChange?: (next: string) => void;
     /** Receives the latest HTML when the editor loses focus. */
@@ -25,6 +27,7 @@ type NotesRichTextEditorProps = {
  */
 export function NotesRichTextEditor({
     value,
+    editable = true,
     onChange,
     onBlur,
     onEditorFocus,
@@ -79,6 +82,10 @@ export function NotesRichTextEditor({
             onBlurRef.current?.(html);
         },
     });
+
+    useEffect(() => {
+        if (editor) editor.setEditable(editable);
+    }, [editor, editable]);
 
     // Keep editor content in sync when the external value changes (e.g. page switched)
     useEffect(() => {


### PR DESCRIPTION
- Updated logic to show the notes of the next page when the playback is active.
- Utilized useMemo for efficient page selection based on playback state.
- Adjusted state management and effect dependencies to reflect changes in the display page.
- Ensured notes are saved to the correct page during editing.

This is an interesting problem we should think about across the app. Are there other places we should update things during animation to make it clear what is being referenced (e.g. in the inspector showing page 5 to 6, instead of just page 5)?

This is fixed though, for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes editor now respects playback state: becomes read-only while playing and shows the next page’s notes during playback.

* **Bug Fixes**
  * Notes consistently display the correct page during playback.
  * Editing, focus, and saving reliably apply to the page that was being edited, preventing accidental saves to the wrong page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->