### PR TITLE
fix(#838): don't close rehearsal mark dialog on input blur

### DIFF
--- a/apps/desktop/src/components/timeline/audio/BeatOrMeasureContextMenu.tsx
+++ b/apps/desktop/src/components/timeline/audio/BeatOrMeasureContextMenu.tsx
@@ -140,7 +140,7 @@ const RehearsalMarkInput = ({
         setRehearsalMark(measure?.rehearsalMark ?? "");
     }, [measure?.rehearsalMark]);
 
-    const saveRehearsalMark = () => {
+    const saveRehearsalMark = (shouldClose = true) => {
         if (!measure) return;
 
         const trimmedMark = rehearsalMark.trim();
@@ -160,7 +160,7 @@ const RehearsalMarkInput = ({
             ],
             {
                 onSuccess: () => {
-                    closeParent();
+                    if (shouldClose) closeParent();
                 },
                 onError: (error) => {
                     conToastError(
@@ -191,7 +191,7 @@ const RehearsalMarkInput = ({
                 type="text"
                 value={rehearsalMark}
                 onChange={(e) => setRehearsalMark(e.target.value)}
-                onBlur={saveRehearsalMark}
+                onBlur={() => saveRehearsalMark(false)}
                 onKeyDown={handleKeyDown}
                 onClick={(e) => {
                     e.stopPropagation();
@@ -223,7 +223,7 @@ const TempoInput = ({
     const tolgee = useTolgee();
     const mutation = useMutation(updateBeatsMutationOptions(queryClient));
 
-    const saveTempo = () => {
+    const saveTempo = (shouldClose = true) => {
         const newTempo = parseFloat(tempo);
 
         if (isNaN(newTempo) || newTempo <= 0) {
@@ -252,7 +252,7 @@ const TempoInput = ({
             ],
             {
                 onSuccess: () => {
-                    closeParent();
+                    if (shouldClose) closeParent();
                 },
                 onError: (error) => {
                     conToastError(
@@ -273,7 +273,7 @@ const TempoInput = ({
     };
 
     const handleBlur = () => {
-        saveTempo();
+        saveTempo(false);
     };
 
     // Update tempo when beat changes


### PR DESCRIPTION
## Summary
- `RehearsalMarkInput` and `TempoInput` both called `closeParent()` inside their mutation `onSuccess` callbacks, which fired even when the save was triggered by an `onBlur` event (e.g., user clicking between fields)
- Added a `shouldClose` parameter (default `true`) to `saveRehearsalMark` and `saveTempo`
- Blur handlers now pass `shouldClose=false`; Enter key handlers use the default (`true`), so pressing Enter still closes the popover

## Test plan
- [ ] Open a beat/measure context menu in the timeline
- [ ] Click into the rehearsal mark text field — popover should stay open
- [ ] Click into the tempo field — popover should stay open
- [ ] Change a value and press Enter — popover should close and save
- [ ] Change a value and click outside the popover — popover should close and save

Fixes #838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Context menu for rehearsal marks and tempo controls now remains open when clicking away from input fields, enabling continuous editing without interruption. Pressing Enter still closes the menu as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->