### PR TITLE
change snap build environment

### DIFF
--- a/.github/workflows/desktop-release.yaml
+++ b/.github/workflows/desktop-release.yaml
@@ -37,20 +37,12 @@ jobs:
         uses: pnpm/action-setup@v4.1.0
 
       ############ LINUX ############
-      - name: Install Snapcraft (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
+      - name: Install Snapcraft (Ubuntu x64)
+        if: matrix.os == 'ubuntu-latest'
         run: sudo snap install snapcraft --classic
 
-      - name: Install Snapcraft (Ubuntu ARM)
-        if: matrix.os == 'ubuntu-24.04-arm'
-        run: sudo snap install lxd
-
-      - name: Setup LXD (Ubuntu ARM)
-        if: matrix.os == 'ubuntu-24.04-arm'
-        uses: canonical/setup-lxd@main
-
       - name: Validate Snapcraft credentials on Linux release
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
         run: snapcraft whoami -q
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
@@ -92,6 +84,7 @@ jobs:
           release: true
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
+          args: ${{ matrix.os == 'ubuntu-24.04-arm' && '--linux AppImage' || '' }}
           max_attempts: 5
         env:
           APPLE_API_KEY: "~/private_keys/apple_api_key.p8"
@@ -108,7 +101,7 @@ jobs:
           SNAPCRAFT_BUILD_ENVIRONMENT: lxd
 
       - name: Promote snap to stable channel
-        if: startsWith(matrix.os, 'ubuntu')
+        if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           # Get the latest revision for this architecture

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -28,6 +28,7 @@ jobs:
               - 'tsconfig.json'
               - 'turbo.json'
               - '.github/workflows/**'
+              - 'actions/**'
 
   basic-checks:
     strategy:
@@ -186,7 +187,6 @@ jobs:
           max_attempts: 3
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false # No code signing on PRs
-          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -192,7 +192,7 @@ jobs:
           max_attempts: 3
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false # No code signing on PRs
-          SNAPCRAFT_BUILD_ENVIRONMENT: lxd
+          SNAPCRAFT_BUILD_ENVIRONMENT: host
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -150,17 +150,9 @@ jobs:
         uses: pnpm/action-setup@v4.1.0
 
       ############ LINUX ############
-      - name: Install Snapcraft (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
+      - name: Install Snapcraft (Ubuntu x64)
+        if: matrix.os == 'ubuntu-latest'
         run: sudo snap install snapcraft --classic
-
-      - name: Install Snapcraft (Ubuntu ARM)
-        if: matrix.os == 'ubuntu-24.04-arm'
-        run: sudo snap install lxd
-
-      - name: Setup LXD (Ubuntu ARM)
-        if: matrix.os == 'ubuntu-24.04-arm'
-        uses: canonical/setup-lxd@main
 
       - name: Create Sentry env file
         working-directory: apps/desktop
@@ -190,6 +182,7 @@ jobs:
           release: false
           mac_certs: ${{ secrets.mac_certs }}
           mac_certs_password: ${{ secrets.mac_certs_password }}
+          args: ${{ matrix.os == 'ubuntu-24.04-arm' && '--linux AppImage' || '' }}
           max_attempts: 3
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false # No code signing on PRs

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -27,6 +27,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'tsconfig.json'
               - 'turbo.json'
+              - '.github/workflows/**'
 
   basic-checks:
     strategy:


### PR DESCRIPTION
Building the snap for ARM linux is very painful 🥲
Hopefully this will get easier, but for now it seems best to just disable it. AppImage will still be available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined desktop build and release workflows: Snapcraft/LXD setup now runs only on the primary Ubuntu runner and ARM-specific LXD steps were removed.
  * Packaging behavior adjusted to produce an AppImage for a specific ARM Linux variant only.
  * PR checks updated so workflow-related changes properly flag desktop-related pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->